### PR TITLE
Set scrollbars to 12 px wide rather than 8px

### DIFF
--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -125,3 +125,8 @@ button {
     outline: 0 !important;
   }
 }
+
+::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}


### PR DESCRIPTION
Should overwrite the setting in reset.scss. This is untested at this point.